### PR TITLE
Update  destructuring/in-params

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = {
     "unicorn/import-index": 2,
     "unicorn/regex-shorthand": 1,
 
-    "destructuring/in-params": [1, { "max-params" : 0 }],
+    "destructuring/in-params": [1, { "max-params" : 1 }],
 
     "computed-property-spacing": [1, "never"],
     "dot-notation": [1, { "allowPattern": "^[a-z]+(_[a-z]+)+$" }],


### PR DESCRIPTION
This will allow single parameter destructuring and multiple level
destructuring:
```
function foo ({ a, b, c})
function foo ({ a: { b } })
```

But will disallow other parameters with a destructure:
```
function for ({ a, b, c }, d)
```

We would prefer to also disallow multiple level destructuring, but
its not possible so we're going to compromise and allow it for now.